### PR TITLE
Add DependenciesHealthcheck dependency

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @RB387 @jerry-git
+*   @RB387 @jerry-git @erhosen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `magic_di.healthcheck.DependenciesHealthcheck` class to make health checks of injected dependencies that implement `magic_di.healthcheck.PingableProtocol` interface
+### Fixed
+- Inject dependencies inside of event loop in `magic_di.utils.inject_and_run` to prevent wrong event loop usage inside of the injected dependencies
 ### Changed
 - Cruft update to get changes from the cookiecutter template
 - Renamed LICENCE -> LICENSE, now it's automatically included in the wheel created by poetry

--- a/src/magic_di/_container.py
+++ b/src/magic_di/_container.py
@@ -4,12 +4,11 @@ import functools
 import inspect
 from dataclasses import dataclass
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from magic_di import ConnectableProtocol
 
 T = TypeVar("T")
 
@@ -53,7 +52,7 @@ class SingletonDependencyContainer:
         self,
         *,
         reverse: bool = False,
-    ) -> Iterable[tuple[type, ConnectableProtocol]]:
+    ) -> Iterable[tuple[type, object]]:
         with self._lock:
             deps_iter: Iterable[Dependency[Any]] = list(
                 reversed(self._deps.values()) if reverse else self._deps.values(),
@@ -70,8 +69,8 @@ class SingletonDependencyContainer:
 
 def _wrap(obj: type[T], *args: Any, **kwargs: Any) -> type[T]:
     if not inspect.isclass(obj):
-        partial = functools.wraps(obj)(functools.partial(obj, *args, **kwargs))  # type: ignore[var-annotated]
-        return cast(type[T], partial)
+        partial: type[T] = functools.wraps(obj)(functools.partial(obj, *args, **kwargs))  # type: ignore[assignment]
+        return partial
 
     _instance: T | None = None
 

--- a/src/magic_di/_utils.py
+++ b/src/magic_di/_utils.py
@@ -27,6 +27,7 @@ def get_cls_from_optional(cls: T) -> T:
     Extract the actual class from a union that includes None.
     If it is not a union type hint, it returns the same type hint.
     Example:
+    ```python
         >>> get_cls_from_optional(Union[str, None])
         str
         >>> get_cls_from_optional(str | None)
@@ -35,6 +36,7 @@ def get_cls_from_optional(cls: T) -> T:
         str
         >>> get_cls_from_optional(int)
         int
+    ```
     Args:
         cls (T): Type hint for class
     Returns:
@@ -73,7 +75,7 @@ def safe_is_instance(sub_cls: Any, cls: type) -> bool:
         return False
 
 
-def is_injectable(cls: Any) -> bool:
+def is_connectable(cls: Any) -> ConnectableProtocol | None:
     """
     Check if a class is a subclass of ConnectableProtocol.
 
@@ -81,9 +83,14 @@ def is_injectable(cls: Any) -> bool:
         cls (Any): The class to check.
 
     Returns:
-        bool: True if the class is a subclass of ConnectableProtocol, False otherwise.
+        ConnectableProtocol | None: return instance if the class
+        is a subclass of ConnectableProtocol, None otherwise.
     """
-    return safe_is_subclass(cls, ConnectableProtocol) or safe_is_instance(cls, ConnectableProtocol)
+    connectable = safe_is_subclass(cls, ConnectableProtocol) or safe_is_instance(
+        cls,
+        ConnectableProtocol,
+    )
+    return cls if connectable else None
 
 
 def get_type_hints(obj: Any, *, include_extras: bool = False) -> dict[str, type]:

--- a/src/magic_di/healthcheck.py
+++ b/src/magic_di/healthcheck.py
@@ -1,0 +1,59 @@
+import asyncio
+from asyncio import Future
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from magic_di import Connectable, ConnectableProtocol, DependencyInjector
+
+
+class PingableProtocol(ConnectableProtocol, Protocol):
+    async def __ping__(self) -> None: ...
+
+
+@dataclass
+class DependenciesHealthcheck(Connectable):
+    """
+    Injectable Healthcheck component that pings all injected dependencies
+    that implement the PingableProtocol
+
+    Example usage:
+
+    ```python
+    from app.components.services.health import DependenciesHealthcheck
+
+    async def main(redis: Redis, deps_healthcheck: DependenciesHealthcheck) -> None:
+        await deps_healthcheck.ping_dependencies()  # redis will be pinged if it has method __ping__
+
+    inject_and_run(main)
+    ```
+    """
+
+    injector: DependencyInjector
+
+    async def ping_dependencies(self, max_concurrency: int = 1) -> None:
+        """
+        Ping all dependencies that implement the PingableProtocol
+
+        :param max_concurrency: Maximum number of concurrent pings
+        """
+        tasks: set[Future[Any]] = set()
+
+        try:
+            for dependency in self.injector.get_dependencies_by_interface(PingableProtocol):
+                tasks.add(asyncio.ensure_future(dependency.__ping__()))
+
+                if len(tasks) >= max_concurrency:
+                    tasks, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+            if tasks:
+                await asyncio.gather(*tasks)
+                tasks = set()
+
+        finally:
+            for task in tasks:
+                task.cancel()
+
+            if tasks:
+                with suppress(asyncio.CancelledError):
+                    await asyncio.gather(*tasks)

--- a/src/magic_di/healthcheck.py
+++ b/src/magic_di/healthcheck.py
@@ -68,10 +68,6 @@ class DependenciesHealthcheck(Connectable):
         dependency_name = dependency.__class__.__name__
         self.injector.logger.debug("Pinging dependency %s...", dependency_name)
 
-        try:
-            await dependency.__ping__()
-        except Exception as exc:
-            self.injector.logger.exception("Failed to ping dependency %s", dependency_name)
-            raise exc  # noqa: TRY201
-        else:
-            self.injector.logger.debug("Dependency %s is healthy", dependency_name)
+        await dependency.__ping__()
+
+        self.injector.logger.debug("Dependency %s is healthy", dependency_name)

--- a/src/magic_di/testing.py
+++ b/src/magic_di/testing.py
@@ -22,18 +22,20 @@ class InjectableMock(AsyncMock):
     and use AsyncMock instead of a real class instance
 
     Example:
-        @pytest.fixture()
-        def client():
-          injector = DependencyInjector()
+    ```python
+    @pytest.fixture()
+    def client():
+      injector = DependencyInjector()
 
-          with injector.override({Service: InjectableMock().mock_cls}):
-            with TestClient(app) as client:
-                yield client
+      with injector.override({Service: InjectableMock().mock_cls}):
+        with TestClient(app) as client:
+            yield client
 
-        def test_http_handler(client):
-          resp = client.post('/hello-world')
+    def test_http_handler(client):
+      resp = client.post('/hello-world')
 
-          assert resp.status_code == 200
+      assert resp.status_code == 200
+    ```
     """
 
     @property

--- a/src/magic_di/utils.py
+++ b/src/magic_di/utils.py
@@ -53,9 +53,9 @@ def inject_and_run(
     """
     injector = injector or DependencyInjector()
 
-    injected = injector.inject(fn)
-
     async def run() -> T:
+        injected = injector.inject(fn)
+
         async with injector:
             if inspect.iscoroutinefunction(fn):
                 return await injected()  # type: ignore[misc,no-any-return]

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+
+import pytest
+from magic_di import Connectable, DependencyInjector
+from magic_di.healthcheck import DependenciesHealthcheck
+
+
+@dataclass
+class PingableDatabase(Connectable):
+    ping_count: int = 0
+
+    async def __ping__(self) -> None:
+        self.ping_count += 1
+
+
+@dataclass
+class Service(Connectable):
+    ping_count: int = 0
+
+
+@dataclass
+class PingableService(Connectable):
+    db: PingableDatabase
+    ping_count: int = 0
+
+    async def __ping__(self) -> None:
+        self.ping_count += 1
+
+
+@pytest.mark.asyncio()
+async def test_healthcheck(injector: DependencyInjector) -> None:
+    async def main(_: PingableService) -> None: ...
+
+    await injector.inject(main)()
+
+    injected_db = injector.inject(PingableDatabase)()
+    injected_srv = injector.inject(PingableService)()
+    injected_srv_not_pingable = injector.inject(Service)()
+
+    assert injected_db.ping_count == 0
+    assert injected_srv.ping_count == 0
+    assert injected_srv_not_pingable.ping_count == 0
+
+    healthcheck = injector.inject(DependenciesHealthcheck)()
+
+    await healthcheck.ping_dependencies(max_concurrency=1)
+
+    assert injected_db.ping_count == 1
+    assert injected_srv.ping_count == 1
+    assert injected_srv_not_pingable.ping_count == 0
+
+    await healthcheck.ping_dependencies(max_concurrency=3)
+
+    assert injected_db.ping_count == 2  # noqa: PLR2004
+    assert injected_srv.ping_count == 2.0  # noqa: PLR2004
+    assert injected_srv_not_pingable.ping_count == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
-from magic_di import DependencyInjector
+import asyncio
+
+from magic_di import ConnectableProtocol, DependencyInjector
 from magic_di.utils import inject_and_run
 
 from tests.conftest import Repository
@@ -25,3 +27,15 @@ def test_inject_and_run_async(injector: DependencyInjector) -> None:
     repo = inject_and_run(main, injector=injector)
     assert not repo.connected
     assert not repo.db.connected
+
+
+def test_inject_and_run_async_proper_event_loop(injector: DependencyInjector) -> None:
+    class DependencyWithEventLoop(ConnectableProtocol):
+        def __init__(self) -> None:
+            self.event_loop = asyncio.get_event_loop()
+
+    async def main(dependency: DependencyWithEventLoop) -> None:
+        event_loop = asyncio.get_running_loop()
+        assert event_loop is dependency.event_loop
+
+    inject_and_run(main, injector=injector)


### PR DESCRIPTION
## Description

### Added
- Added `magic_di.healthcheck.DependenciesHealthcheck` class to make health checks of injected dependencies that implement `magic_di.healthcheck.PingableProtocol` interface
### Fixed
- Inject dependencies inside of event loop in `magic_di.utils.inject_and_run` to prevent wrong event loop usage inside of the injected dependencies

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
