### PR TITLE
Fix Python3.10 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- Fixed compatibility with Python3.10 for optional type hints
+
 ## [0.2.0] - 2024-09-27
 ### Added
 - Added `magic_di.healthcheck.DependenciesHealthcheck` class to make health checks of injected dependencies that implement `magic_di.healthcheck.PingableProtocol` interface

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ class Service(Connectable):
     dependency: Annotated[NonConnectableDependency, Injectable]
 ```
 
-## Healthchecks
+## Healthcheck
 You can implement `Pingable` protocol to define healthchecks for your clients. The `DependenciesHealthcheck` will call the `__ping__` method on all injected clients that implement this protocol.
 
 ```python

--- a/src/magic_di/_utils.py
+++ b/src/magic_di/_utils.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, TypeVar, cast, get_args
+from typing import Any, Optional, TypeVar, cast, get_args
 from typing import get_type_hints as _get_type_hints
 
 from magic_di import ConnectableProtocol
 
 LegacyUnionType = type(object | None)
+LegacyOptionalType = type(Optional[object])  # noqa: UP007
 
 try:
     from types import UnionType  # type: ignore[import-error,unused-ignore]
@@ -27,7 +28,7 @@ def get_cls_from_optional(cls: T) -> T:
     Extract the actual class from a union that includes None.
     If it is not a union type hint, it returns the same type hint.
     Example:
-    ```python
+    ``` py
         >>> get_cls_from_optional(Union[str, None])
         str
         >>> get_cls_from_optional(str | None)
@@ -36,13 +37,15 @@ def get_cls_from_optional(cls: T) -> T:
         str
         >>> get_cls_from_optional(int)
         int
+        >>> get_cls_from_optional(Optional[str])
+        str
     ```
     Args:
         cls (T): Type hint for class
     Returns:
         T: Extracted class
     """
-    if not isinstance(cls, UnionType | LegacyUnionType):
+    if not isinstance(cls, UnionType | LegacyUnionType | LegacyOptionalType):
         return cls
 
     args = get_args(cls)

--- a/src/magic_di/healthcheck.py
+++ b/src/magic_di/healthcheck.py
@@ -19,7 +19,7 @@ class DependenciesHealthcheck(Connectable):
 
     Example usage:
 
-    ```python
+    ``` py
     from app.components.services.health import DependenciesHealthcheck
 
     async def main(redis: Redis, deps_healthcheck: DependenciesHealthcheck) -> None:

--- a/src/magic_di/testing.py
+++ b/src/magic_di/testing.py
@@ -22,7 +22,7 @@ class InjectableMock(AsyncMock):
     and use AsyncMock instead of a real class instance
 
     Example:
-    ```python
+    ``` py
     @pytest.fixture()
     def client():
       injector = DependencyInjector()

--- a/tests/test_injector.py
+++ b/tests/test_injector.py
@@ -61,6 +61,21 @@ async def test_function_injection_success(injector: DependencyInjector) -> None:
     assert isinstance(service, Service)
 
 
+@pytest.mark.asyncio()
+async def test_function_injection_success_legacy_optional(injector: DependencyInjector) -> None:
+    def run_service(service: Service | None) -> Service:
+        assert service is not None
+        return service
+
+    injected = injector.inject(run_service)
+
+    async with injector:
+        service = injected()
+        assert service.is_alive()
+
+    assert isinstance(service, Service)
+
+
 def test_class_injection_missing_class(injector: DependencyInjector) -> None:
     with pytest.raises(InjectionError):
         injector.inject(BrokenService)


### PR DESCRIPTION
## Description

Fixed compatibility with Python 3.10

It doesn't correctly unwraps Optional types on this version.
`int | None` == `Optional[int]` != `Union[int, None]`

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
