### PR TITLE
Fix type hinting in PyCharm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Compatibility with PyCharm for FastAPI `Provide` type hints
+
+### Removed
+- Removed `Provider` class
 
 ## [0.2.1] - 2024-10-01
 ### Fixed

--- a/src/magic_di/fastapi/__init__.py
+++ b/src/magic_di/fastapi/__init__.py
@@ -3,6 +3,6 @@ Package containing tools for integrating Dependency Injector with FastAPI framew
 """
 
 from ._app import inject_app
-from ._provide import Provide, Provider  # type: ignore[attr-defined]
+from ._provide import Provide  # type: ignore[attr-defined]
 
-__all__ = ("inject_app", "Provide", "Provider")
+__all__ = ("inject_app", "Provide")

--- a/src/magic_di/fastapi/_provide.py
+++ b/src/magic_di/fastapi/_provide.py
@@ -16,26 +16,25 @@ T = TypeVar("T")
 class FastAPIInjectionError(Exception): ...
 
 
-class Provider:
-    def __getitem__(self, obj: type[T]) -> type[T]:
-        @lru_cache(maxsize=1)
-        def get_dependency(injector: DependencyInjector) -> T:
-            return injector.inject(obj)()
-
-        def inject(request: Request) -> T:
-            if not hasattr(request.app.state, "dependency_injector"):
-                error_msg = (
-                    "FastAPI application is not injected. Did you forget to add `inject_app(app)`?"
-                )
-                raise FastAPIInjectionError(error_msg)
-
-            injector = request.app.state.dependency_injector
-            return get_dependency(injector)
-
-        return Annotated[obj, Depends(inject), Injectable]  # type: ignore[return-value]
-
-
 if TYPE_CHECKING:
     from typing import Union as Provide  # hack for mypy # noqa: FIX004
 else:
-    Provide = Provider()
+
+    class Provide:
+        def __class_getitem__(cls, obj: T) -> T:
+            @lru_cache(maxsize=1)
+            def get_dependency(injector: DependencyInjector) -> T:
+                return injector.inject(obj)()
+
+            def inject(request: Request) -> T:
+                if not hasattr(request.app.state, "dependency_injector"):
+                    error_msg = (
+                        "FastAPI application is not injected. "
+                        "Did you forget to add `inject_app(app)`?"
+                    )
+                    raise FastAPIInjectionError(error_msg)
+
+                injector = request.app.state.dependency_injector
+                return get_dependency(injector)
+
+            return Annotated[obj, Depends(inject), Injectable]  # type: ignore[return-value]


### PR DESCRIPTION
## Description

In the newest versions of PyCharm, the type hints with magic-di’s FastAPI integration are broken. This pull request aims to fix the issue without breaking compatibility with MyPy

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
