### PR TITLE
Handle mounted apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Skip mounted sub-applications (`starlette.routing.Mount`) during dependency collection instead of raising a `TypeError`
+
 ### Changed
 - Replaced the `Union as Provide` mypy hack with an `Annotated`/`TypeVar` based type alias for the FastAPI `Provide` type hint
 - Updated dependecies collection to support FastAPI 0.137.0+ versions

--- a/src/magic_di/fastapi/_app.py
+++ b/src/magic_di/fastapi/_app.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 from fastapi.params import Depends
+from starlette.routing import Mount
 
 from magic_di._injector import DependencyInjector
 
@@ -131,6 +132,9 @@ def _collect_dependencies(  # noqa: C901
     for route in app_router.routes:
         if isinstance(route, IncludedRouterProtocol):
             _collect_dependencies(injector, route.original_router)
+            continue
+
+        if isinstance(route, Mount):
             continue
 
         if not isinstance(route, RouterProtocol):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 import pytest
 from fastapi import APIRouter, Depends, FastAPI
+from starlette.routing import Mount
 from starlette.testclient import TestClient
 
 from magic_di import DependencyInjector
@@ -154,6 +155,34 @@ def test_app_injection_collects_included_router_dependencies(
     with TestClient(app) as client:
         resp = client.get("/hello-world")
         assert resp.json() == {"connected": True}
+
+
+def test_app_injection_skips_mounted_apps(injector: DependencyInjector) -> None:
+    app = inject_app(FastAPI(), injector=injector)
+
+    @app.get(path="/hello-world")
+    def hello_world(service: Provide[Service]) -> dict[str, bool]:
+        return {"connected": service.connected}
+
+    sub_app = FastAPI()
+
+    @sub_app.get(path="/sub")
+    def sub() -> dict[str, bool]:
+        return {"ok": True}
+
+    # Mounted apps appear as starlette.routing.Mount nodes in app.router.routes.
+    # They must be skipped during dependency collection rather than raising a
+    # TypeError for not matching RouterProtocol.
+    app.mount("/mounted", sub_app)
+
+    assert any(isinstance(route, Mount) for route in app.router.routes)
+
+    with TestClient(app) as client:
+        resp = client.get("/hello-world")
+        assert resp.json() == {"connected": True}
+
+        resp = client.get("/mounted/sub")
+        assert resp.json() == {"ok": True}
 
 
 def test_app_injection_without_registered_injector(injector: DependencyInjector) -> None:


### PR DESCRIPTION
## Description

Skip mounted sub-applications (`starlette.routing.Mount`) during dependency collection instead of raising a `TypeError`
 here.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
